### PR TITLE
Avoid overwriting headers with defaults before sending requests

### DIFF
--- a/Runtime/Http/ApiClient.cs
+++ b/Runtime/Http/ApiClient.cs
@@ -226,7 +226,10 @@ namespace MetafabSdk
 			headers["Accept"] = "application/json";
 			foreach (var entry in this.headers)
 			{
-				headers[entry.Key] = entry.Value;
+				if (!headers.ContainsKey(entry.Key))
+				{
+					headers[entry.Key] = entry.Value;
+				}
 			}
 
 			if (!string.IsNullOrEmpty(accessToken))


### PR DESCRIPTION
When performing requests like `SetPlayerConnectedWallet` the `X-Authorization` headers needs to me set to the player's access token and at the moment the SDK will override this header with the game's secret key which will cause a 401 error.

This change will prevent overriding custom headers to avoid this issue.